### PR TITLE
Enforcing need to input both day of birth and day of passing

### DIFF
--- a/app/components/CVDatepicker.vue
+++ b/app/components/CVDatepicker.vue
@@ -1,10 +1,10 @@
 <template lang="pug">
-Datepicker(class="rounded-md p-2" :id="id" type="Date" v-model="value" auto-apply)
+VueDatePicker(class="rounded-md p-2" :id="id" type="Date" v-model="value" auto-apply)
     slot
 </template>
         
 <script setup lang="ts">
-import Datepicker from '@vuepic/vue-datepicker';
+import { VueDatePicker } from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
 
 const props = defineProps<{

--- a/app/pages/EditPage/[EditPageId].vue
+++ b/app/pages/EditPage/[EditPageId].vue
@@ -14,6 +14,7 @@ definePageMeta({
 })
 
 import { dateFormat, donationFormat } from '@/utils'
+import { VueDatePicker } from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
 import { ChevronDownIcon, ChevronLeftIcon } from '@heroicons/vue/24/solid'
 import { vElementSize } from '@vueuse/components'
@@ -86,6 +87,25 @@ const page = ref<Page>({
         FamilyDonations: [],
         advocateCuid: ""
     } 
+})
+
+// Adapter that ensures VueDatePicker in range mode updates day_of_birth and day_of_passing when updated by user
+const dateRange = computed({
+  get() {
+    if (page.value.day_of_birth && page.value.day_of_passing) {
+      return [page.value.day_of_birth, page.value.day_of_passing]
+    }
+    return null
+  },
+  set(newValue) {
+    if (newValue && newValue[0] && newValue[1]) {
+      page.value.day_of_birth = newValue[0]
+      page.value.day_of_passing = newValue[1]
+    } else {
+      page.value.day_of_birth = null
+      page.value.day_of_passing = null
+    }
+  }
 })
 
 const isAdvocate = computed(() => user.value?.role == "advocate" || user.value?.role == "admin")
@@ -196,6 +216,7 @@ const onResize = ({ width, height }: { width: number, height: number }) => {
         profileImgHeight.value = 40
     }
 }
+
 </script>
 
 <template lang="pug">
@@ -265,14 +286,18 @@ description="Here, you select from photos you uploaded to show up at the top of 
                             CVChevronDown(v-else class="inline-block size-4 h-2 max-w-8 h-4 text-gray-500 z-3")
                             
                           
+        // Day of Birth - Day of Passing
         div(class="py-4 grid sm:grid-cols-3") 
-            CVLabel(for="day_of_birth") Day of Birth
+            CVLabel(for="birth-passing") Dates of Life
             div(class="mx-9 sm:col-span-2 sm:mr-11")
-                CVDatepicker(id="day_of_birth" v-model='page.day_of_birth')
-        div(class="py-4 grid sm:grid-cols-3") 
-            CVLabel(for="day_of_passing") Day of Passing 
-            div(class="mx-9 sm:col-span-2 sm:mr-11")
-                CVDatepicker(id="day_of_birth" v-model='page.day_of_passing')
+                VueDatePicker(
+                  id="birth-passing"
+                  class="rounded-md p-2"
+                  auto-apply
+                  v-model="dateRange"
+                  :range={ partialRange: false }
+                )
+
         div(class="information rounded-md mx-9 my-2 text-center sm:text-start text-white bg-blue-999")
             CVLegend Visitation Information 
         div(class="py-4 grid sm:grid-cols-3") 

--- a/app/pages/Page/[id].vue
+++ b/app/pages/Page/[id].vue
@@ -192,7 +192,7 @@ div(class="grid grid-cols-1 sm:grid-cols-2 justify-center px-2")
   div(class="col-span-2")
     div(class="flex flex-col gap-5 px-4 mx-auto mt-8 w-3/4 sm:px-16")
       img(v-if="profileImage?.url" :src="`${profileImage?.url}`" class="mx-auto w-[122px] h-[122px] rounded-[8px]")
-      div(class="text-gray-dark mx-auto w-max font-poppins text-md") {{ dateFormat(pageDataDB.day_of_birth, true) + ((pageDataDB.day_of_birth || pageDataDB.day_of_passing) ? ' - ' : '') + dateFormat(pageDataDB.day_of_passing, true) }} 
+      div(class="text-gray-dark mx-auto w-max font-poppins text-md") {{(pageDataDB.day_of_birth && pageDataDB.day_of_passing) ?  dateFormat(pageDataDB.day_of_birth, true) + ' - ' + dateFormat(pageDataDB.day_of_passing, true) : '' }} 
   div(class="col-span-1 justify-self-end pr-5 pt-5")
     div(v-if="imageData.length != 0" class="relative w-96 p-1")
       button(@click="prevImage" class="absolute left-4 top-64 bg-black text-white opacity-70 w-[46px] h-[46px] rounded-full items-center justify-center leading-loose text-center text-white") &#60;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@prisma/client": "^7.7.0",
     "@suadelabs/vue3-multiselect": "^1.0.2",
     "@tensorflow-models/toxicity": "^1.2.2",
-    "@vuepic/vue-datepicker": "^5.4.0",
+    "@vuepic/vue-datepicker": "^12.1.0",
     "@vueuse/components": "^13.1.0",
     "autoprefixer": "^10.4.19",
     "better-auth": "^1.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2(@tensorflow/tfjs-converter@1.7.4(@tensorflow/tfjs-core@1.7.4))(@tensorflow/tfjs-core@1.7.4)
       '@vuepic/vue-datepicker':
-        specifier: ^5.4.0
-        version: 5.4.0(vue@3.5.32(typescript@5.9.3))
+        specifier: ^12.1.0
+        version: 12.1.0(vue@3.5.32(typescript@5.9.3))
       '@vueuse/components':
         specifier: ^13.1.0
         version: 13.9.0(vue@3.5.32(typescript@5.9.3))
@@ -528,10 +528,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/runtime@7.28.6':
-    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -660,6 +656,9 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       postcss-selector-parser: ^7.0.0
+
+  '@date-fns/tz@1.4.1':
+    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
   '@dxup/nuxt@0.4.0':
     resolution: {integrity: sha512-28LDotpr9G2knUse3cQYsOo6NJq5yhABv4ByRVRYJUmzf9Q31DI7rpRek4POlKy1aAcYyKgu5J2616pyqLohYg==}
@@ -1048,6 +1047,18 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@floating-ui/vue@1.1.11':
+    resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
 
   '@hapi/boom@10.0.1':
     resolution: {integrity: sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==}
@@ -2883,11 +2894,11 @@ packages:
   '@vue/shared@3.5.32':
     resolution: {integrity: sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==}
 
-  '@vuepic/vue-datepicker@5.4.0':
-    resolution: {integrity: sha512-9f1ZqRDfak/UmBbD81BdqMDpUku2YphTwQXG8DF6hsrjIXsq5sX7BWJB6LhyVgvX9QFrSyFIp4fsHE3UFofZ7A==}
-    engines: {node: '>=14'}
+  '@vuepic/vue-datepicker@12.1.0':
+    resolution: {integrity: sha512-QuWcO+CqIGYFoRNCagp9xUY9sMK/OHUlVIDxBYjw7HjCTWXfuE/r3l3loB00faEtb0Teo3DeBn26hT3tYA5pgg==}
+    engines: {node: '>=18.12.0'}
     peerDependencies:
-      vue: '>=3.2.0'
+      vue: '>=3.5.0'
 
   '@vueuse/components@13.9.0':
     resolution: {integrity: sha512-0DDFpjG3hEEK+3YgSzE/OzOGqpo/KmxcXWzW2YdmgahZvaoUdegn68GmbdcHRJE7CH55dDj13Cz47iN8QoI3jQ==}
@@ -2899,11 +2910,24 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
+  '@vueuse/core@14.3.0':
+    resolution: {integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==}
+    peerDependencies:
+      vue: ^3.5.0
+
   '@vueuse/metadata@13.9.0':
     resolution: {integrity: sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==}
 
+  '@vueuse/metadata@14.3.0':
+    resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
+
   '@vueuse/shared@13.9.0':
     resolution: {integrity: sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/shared@14.3.0':
+    resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
     peerDependencies:
       vue: ^3.5.0
 
@@ -3711,14 +3735,8 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  date-fns-tz@1.3.8:
-    resolution: {integrity: sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==}
-    peerDependencies:
-      date-fns: '>=2.0.0'
-
-  date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   db0@0.3.4:
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
@@ -6870,6 +6888,17 @@ packages:
   vue-bundle-renderer@2.2.0:
     resolution: {integrity: sha512-sz/0WEdYH1KfaOm0XaBmRZOWgYTEvUDt6yPYaUzl4E52qzgWLlknaPPTTZmp6benaPTlQAI/hN1x3tAzZygycg==}
 
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
 
@@ -8027,8 +8056,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/runtime@7.28.6': {}
-
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -8135,6 +8162,8 @@ snapshots:
   '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.1)':
     dependencies:
       postcss-selector-parser: 7.1.1
+
+  '@date-fns/tz@1.4.1': {}
 
   '@dxup/nuxt@0.4.0(magicast@0.5.2)(typescript@5.9.3)':
     dependencies:
@@ -8403,6 +8432,26 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/utils@0.2.11': {}
+
+  '@floating-ui/vue@1.1.11(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@floating-ui/utils': 0.2.11
+      vue-demi: 0.14.10(vue@3.5.32(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
 
   '@hapi/boom@10.0.1':
     dependencies:
@@ -10575,11 +10624,15 @@ snapshots:
 
   '@vue/shared@3.5.32': {}
 
-  '@vuepic/vue-datepicker@5.4.0(vue@3.5.32(typescript@5.9.3))':
+  '@vuepic/vue-datepicker@12.1.0(vue@3.5.32(typescript@5.9.3))':
     dependencies:
-      date-fns: 2.30.0
-      date-fns-tz: 1.3.8(date-fns@2.30.0)
+      '@date-fns/tz': 1.4.1
+      '@floating-ui/vue': 1.1.11(vue@3.5.32(typescript@5.9.3))
+      '@vueuse/core': 14.3.0(vue@3.5.32(typescript@5.9.3))
+      date-fns: 4.1.0
       vue: 3.5.32(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   '@vueuse/components@13.9.0(vue@3.5.32(typescript@5.9.3))':
     dependencies:
@@ -10594,9 +10647,22 @@ snapshots:
       '@vueuse/shared': 13.9.0(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
 
+  '@vueuse/core@14.3.0(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 14.3.0
+      '@vueuse/shared': 14.3.0(vue@3.5.32(typescript@5.9.3))
+      vue: 3.5.32(typescript@5.9.3)
+
   '@vueuse/metadata@13.9.0': {}
 
+  '@vueuse/metadata@14.3.0': {}
+
   '@vueuse/shared@13.9.0(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      vue: 3.5.32(typescript@5.9.3)
+
+  '@vueuse/shared@14.3.0(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       vue: 3.5.32(typescript@5.9.3)
 
@@ -11252,13 +11318,7 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  date-fns-tz@1.3.8(date-fns@2.30.0):
-    dependencies:
-      date-fns: 2.30.0
-
-  date-fns@2.30.0:
-    dependencies:
-      '@babel/runtime': 7.28.6
+  date-fns@4.1.0: {}
 
   db0@0.3.4(@electric-sql/pglite@0.4.1)(better-sqlite3@12.9.0)(mysql2@3.15.3):
     optionalDependencies:
@@ -14795,6 +14855,10 @@ snapshots:
   vue-bundle-renderer@2.2.0:
     dependencies:
       ufo: 1.6.3
+
+  vue-demi@0.14.10(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      vue: 3.5.32(typescript@5.9.3)
 
   vue-devtools-stub@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,4 @@ onlyBuiltDependencies:
   - esbuild
   - prisma
   - unrs-resolver
+  - vue-demi

--- a/server/api/page/index.put.ts
+++ b/server/api/page/index.put.ts
@@ -29,7 +29,6 @@ export default defineEventHandler(async event => {
       }
       if(typeof data.amount_raised == 'string') {
         data.amount_raised = Math.trunc(parseFloat(data.amount_raised.replace(",","")) * 100);
-        console.log("amount raised after removing formating ", data.amount_raised)
       }
       // updates a pre-existing page
       const queryRes = await prisma.page.update({


### PR DESCRIPTION
Updated `/Page/:id` so that it only displays the range of life if both day of birth and day of passing exist. Also updated date pickers for day of birth and day of passing to be one single date picker that picks a range. This is a more straightforward experience on for UX and helps enforce that both dates must be set or both left null.